### PR TITLE
Fixed a typo in code block on installation page

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -185,7 +185,7 @@ and build using `meson` and install using `ninja`:
 mkdir build
 meson build && cd build
 ninja -j$(nproc)
-$ ninja install
+ninja install
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
There was an extraneous "$ " before the last command in the instructions for building from source, so small commit to fix that typo.