### PR TITLE
Update broken links in README.md for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ In Bottles we call these environments bottles.
 
 ## Where to start?
 
-It's simple. Start by [installing](getting-started/installation.md) Bottles on your Linux distribution.
+It's simple. Start by [installing](getting-started/installation) Bottles on your Linux distribution.
 
 ## First run
 
-Already installed? Let's go with the [first boot](getting-started/first-run.md) of Bottles!
+Already installed? Let's go with the [first boot](getting-started/first-run) of Bottles!


### PR DESCRIPTION
The links point to an MD file, but that is not the correct WEB URL. The side-pane had the correct URL, so I copied it from there to this document.

If I click on the link as it is now, it just takes me to the page that tells you how to download it and doesn't show any documents at all.